### PR TITLE
Avoid overwriting BITRISE_DSYM_PATH environment variable

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -9,8 +9,6 @@ else
   npm install -g appcenter-cli
 fi
 
-envman add --key BITRISE_DSYM_PATH
-
 appcenter crashes upload-symbols -s "$dsym_path" -a $app_id --token $api_token --quiet
 
 exit 0


### PR DESCRIPTION
Briefly tested, seems to be working fine and avoids the environment variable `BITRISE_DSYM_PATH` being empty for the following steps.

Fixes #4